### PR TITLE
Add `index.rst` for using as a folder in Sphinx

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,0 +1,15 @@
+.. _kqcircuits_examples:
+
+..
+  This file is used for including this repository as a folder in Sphinx documentation using nbsphinx.
+
+Example notebooks
+=====================
+
+Example notebooks for KQCircuits. These are fetched from the `KQCircuits-Examples <https://github.com/iqm-finland/KQCircuits-Examples>`_ repository.
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   notebooks/*


### PR DESCRIPTION
We may add the `index.rst` for globbing all the notebooks in the repo here instead of main KQC

Closes #3